### PR TITLE
Automate gem release

### DIFF
--- a/.github/workflows/gem-publish-on-pr-merge.yml
+++ b/.github/workflows/gem-publish-on-pr-merge.yml
@@ -30,3 +30,10 @@ jobs:
       with:
         github_packages_owner: catawiki
         github_packages_token: ${{ secrets.GEM_RELEASE_TOKEN }}
+
+    # # Assumes that the previous step builds and releases the gem to
+    # # rubygems.pkg.github.com and creates ~/.gem/credentials
+    # - name: Push new version to RubyGems.org
+    #   run: >-
+    #     printf -- ":rubygems: Bearer %s\n" "${{ secret.RUBYGEMS_ORG_RELEASE_TOKEN }}" >> "$HOME/.gem/credentials"
+    #     gem push fake-kafka-*.gem --key rubygems --host "https://rubygems.org"

--- a/.github/workflows/gem-publish-on-pr-merge.yml
+++ b/.github/workflows/gem-publish-on-pr-merge.yml
@@ -1,0 +1,32 @@
+name: "Gem: Release new version on PR merge"
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Run if merged and has a version specifying label
+    if: >-
+      github.event.pull_request.merged &&
+      (
+        contains(github.event.pull_request.labels.*.name, 'version:major') ||
+        contains(github.event.pull_request.labels.*.name, 'version:minor') ||
+        contains(github.event.pull_request.labels.*.name, 'version:patch')
+      )
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+      with:
+        # A separate token is needed because the master branch is protected.
+        token: ${{ secrets.GEM_RELEASE_TOKEN }}
+        # Whether to configure the token or SSH key with the local git config
+        persist-credentials: true
+
+    - name: Release new version of the gem
+      uses: "catawiki/gem-release-action@v1"
+      with:
+        github_packages_owner: catawiki
+        github_packages_token: ${{ secrets.GEM_RELEASE_TOKEN }}

--- a/.github/workflows/pr-ensure-version-label.yml
+++ b/.github/workflows/pr-ensure-version-label.yml
@@ -1,0 +1,25 @@
+name: "PR: Add default 'version:no release' label"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labelled
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    # Run if there is no version related label on the PR
+    if: >-
+      !(
+        contains(github.event.pull_request.labels.*.name, 'version:major') ||
+        contains(github.event.pull_request.labels.*.name, 'version:minor') ||
+        contains(github.event.pull_request.labels.*.name, 'version:patch') ||
+        contains(github.event.pull_request.labels.*.name, 'version:no release')
+      )
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          labels: 'version:no release'

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/fake-kafka-*.gem
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fake-kafka (0.0.1.pre.beta1)
+    fake-kafka (0.0.2)
 
 GEM
   remote: https://rubygems.org/

--- a/fake-kafka.gemspec
+++ b/fake-kafka.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "fake/kafka/version"
@@ -12,15 +11,6 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Fake Kafka Consumer and Producer.}
   spec.description   = %q{In memory 'kafka' instruments design for testing integrations with kafka.}
   spec.homepage      = "https://github.com/catawiki/fake-kafka"
-
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "http://mygemserver.com"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
This PR automates the way we publish the gem.

**Problem:**
Currently only Pavel and Gergo can release it manually.

This gem is public. Publishing it requires a Catawiki account on [RubyGems.org](https://rubygems.org/sign_up).

## Tasks

- [ ] Create an account on [RubyGems.org](https://rubygems.org/sign_up) for Catawiki
- [ ] Set a non-OTP token in this repository using the name `RUBYGEMS_ORG_RELEASE_TOKEN`.
- [ ] Uncomment the Action step to publish the next version to RubyGems.org

## Changes

- Remove restriction on push host
- Publish the 0.0.2 version
- Publish gem to GitHub packages registry
- Add example code to push the gem to RubyGems.org
