### PR TITLE
Add license to gemspec; fix Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fake-kafka (0.0.1.pre.beta1)
+    fake-kafka (0.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -32,4 +32,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/fake-kafka.gemspec
+++ b/fake-kafka.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = Fake::Kafka::VERSION
   spec.authors       = ["Sebastian Arcila Valenzuela"]
   spec.email         = ["sebastianarcila@gmail.com"]
-
+  spec.license       = 'MIT'
   spec.summary       = %q{Fake Kafka Consumer and Producer.}
   spec.description   = %q{In memory 'kafka' instruments design for testing integrations with kafka.}
   spec.homepage      = "https://github.com/catawiki/fake-kafka"


### PR DESCRIPTION
We added MIT licence with #12 but the gemspec still needs update. Also update the `Gemfile.lock` with the version bump as well.