### PR TITLE
Update gem release action

### DIFF
--- a/.github/workflows/gem-publish-on-pr-merge.yml
+++ b/.github/workflows/gem-publish-on-pr-merge.yml
@@ -26,7 +26,7 @@ jobs:
         persist-credentials: true
 
     - name: Release new version of the gem
-      uses: "catawiki/gem-release-action@v1"
+      uses: "catawiki/gem-release-action@v1.1"
       with:
         github_packages_owner: catawiki
         github_packages_token: ${{ secrets.GEM_RELEASE_TOKEN }}


### PR DESCRIPTION
This update includes a gix on the action to handle git `safe.directory` config
## [`git-config: safe.directory`](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory)

> These config entries specify Git-tracked directories that are considered safe even if they are owned by someone other than the current user. By default, Git will refuse to even parse a Git config of a repository owned by someone else, let alone run its hooks, and this config setting allows users to specify exceptions, e.g. for intentionally shared repositories (see the `--shared` option in [git-init[1]](https://git-scm.com/docs/git-init)).
>
> This is a multi-valued setting, i.e. you can add more than one directory via git config `--add`. To reset the list of safe directories (e.g. to override any such directories specified in the system config), add a `safe.directory` entry with an empty value.
>
> This config setting is only respected when specified in a system or global config, not when it is specified in a repository config or via the command line option `-c safe.directory=<path>`.
>
> The value of this setting is interpolated, i.e. `~/<path>` expands to a path relative to the home directory and `%(prefix)/<path>` expands to a path relative to Git’s (runtime) prefix.