### PR TITLE
Add Catawiki as author in gemspec

### DIFF
--- a/fake-kafka.gemspec
+++ b/fake-kafka.gemspec
@@ -5,7 +5,7 @@ require "fake/kafka/version"
 Gem::Specification.new do |spec|
   spec.name          = "fake-kafka"
   spec.version       = Fake::Kafka::VERSION
-  spec.authors       = ["Sebastian Arcila Valenzuela"]
+  spec.authors       = ["Catawiki", "Sebastian Arcila Valenzuela"]
   spec.email         = ["opensource@catawiki.nl"]
   spec.license       = 'MIT'
   spec.summary       = %q{Fake Kafka Consumer and Producer.}


### PR DESCRIPTION
As part of Catawiki's internal open source working group, we've decided to add Catawiki as owner of all of our public gems.