### PR TITLE
Move codeowners file and adjust codeowners group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # PATH                                 OWNERS
-*                                      @catawiki/fintech-backend
+*                                      @catawiki/kafka-client-wg


### PR DESCRIPTION
Moving the CODEOWNERS file to the proper GitHub folder and also changing the code owners to the Kafka workgroup Github "team." 